### PR TITLE
Style review

### DIFF
--- a/media/lua/client/AnthroTraitsFunctionHooks.lua
+++ b/media/lua/client/AnthroTraitsFunctionHooks.lua
@@ -1,5 +1,5 @@
-local ATM = AnthroTraitsMain;
-local ATC = AnthroTraitsMainCreationMethods;
+local ATM = require("NPCs/AnthroTraitsMain");
+local ATC = require("NPCs/AnthroTraitsCreationMethods");
 require('AnthroTraitsGlobals');
 
 

--- a/media/lua/client/AnthroTraitsFunctionHooks.lua
+++ b/media/lua/client/AnthroTraitsFunctionHooks.lua
@@ -57,9 +57,9 @@ ISAddItemInRecipe.perform = function(self)
     local tags = {}
 
     --get all tags relating to food, and init table with string keys so their count can be added to
-    for _, tag in pairs(AnthroTraitsGlobals.EvolvedRecipeFoodTags)
+    for i = 1, #AnthroTraitsGlobals.EvolvedRecipeFoodTags
     do
-        tags[tag] = 0;
+        tags[AnthroTraitsGlobals.EvolvedRecipeFoodTags[i]] = 0;
     end
 
     local tagWithLargestCount = "";
@@ -130,9 +130,9 @@ ISBaseTimedAction.create = function(self)
     OriginalTimedActionCreate(self);
     if self.character:HasTrait("AT_UnwieldyHands")
     then
-        for _, action in pairs(AnthroTraitsGlobals.UnwieldyHandsAffectedTimedActions)
+        for i = 1, #AnthroTraitsGlobals.UnwieldyHandsAffectedTimedActions
         do
-            if self.Type == action
+            if self.Type == AnthroTraitsGlobals.UnwieldyHandsAffectedTimedActions[i]
             then
                 local newTime = self.maxTime * (1 + SandboxVars.AnthroTraits.AT_UnwieldyHandsTimeIncrease)
                 if getDebug()

--- a/media/lua/client/AnthroTraitsUtilities.lua
+++ b/media/lua/client/AnthroTraitsUtilities.lua
@@ -1,4 +1,4 @@
-AnthroTraitsUtilities = {}
+local AnthroTraitsUtilities = {}
 
 
 --UTILITIES

--- a/media/lua/client/NPCs/AnthroTraitsMain.lua
+++ b/media/lua/client/NPCs/AnthroTraitsMain.lua
@@ -266,25 +266,31 @@ AnthroTraitsMain.DoVoreModifier = function(character, foodEaten, foodPercentEate
     end
 end
 
+AnthroTraitsMain.ExclaimPhrases = {
+    generic = {"AAAH!", "AAAH!", "AAAH!!", "AEIEEEE!", "EAAH!", "AAAGH!"},
+    yeen = {"HAHAHAHAHA!", "HAHAHAHAHA!", "HAHAHAHAHA!!", "HUHEHEHEHAHA!", "HAAAAH!", "HEEEHEEEHAHAHAHA!"},
+    bleater = {"BLEAT!", "BLEAT!", "BLEAT!!", "BLEAAAAT!", "BLEE-EAT!", "EEEEP!"}
+}
 
 AnthroTraitsMain.ExclaimerCheck = function(player)
     local moodles = player:getMoodles();
     local panicLevel = moodles:getMoodleLevel(MoodleType.Panic);
-    local playerSquare = player:getCurrentSquare();
     local thresholdMultiplier = SandboxVars.AnthroTraits.AT_ExclaimerExclaimThresholdMultiplier;
 
     local exclaimChance = ZombRand(1,100);
-    local phraseChance = ZombRand(1, #AnthroTraitsGlobals.ExclaimPhrases);
 
     if (exclaimChance <= (panicLevel * thresholdMultiplier)) and panicLevel > 1
     then
+        local phrases = AnthroTraitsMain.ExclaimPhrases.generic
+        local phraseChance = ZombRand(1, #phrases);
+        local playerSquare = player:getCurrentSquare();
         --if player:HasTrait("AT_Hooves");
         --then
         --    player:SayShout("BLEAT!");
         --else
         --    player:SayShout("HAHAHAHA!");
         --end
-        player:SayShout(AnthroTraitsGlobals.ExclaimPhrases[phraseChance]);
+        player:SayShout(phrases[phraseChance]);
         getWorldSoundManager():addSound(player,
                 playerSquare:getX(),
                 playerSquare:getY(),

--- a/media/lua/client/NPCs/AnthroTraitsMain.lua
+++ b/media/lua/client/NPCs/AnthroTraitsMain.lua
@@ -1,4 +1,4 @@
-AnthroTraitsMain = {};
+local AnthroTraitsMain = {};
 
 
 AnthroTraitsMain.HandleInfection = function(player)
@@ -803,9 +803,6 @@ Events.EveryHours.Add(AnthroTraitsMain.ATEveryHours);
 Events.EveryOneMinute.Add(AnthroTraitsMain.ATEveryOneMinute);
 Events.OnPlayerGetDamage.Add(AnthroTraitsMain.ATPlayerDamageTick);
 Events.OnPlayerUpdate.Add(AnthroTraitsMain.ATPlayerUpdate);
-
-Events.OnGameBoot.Add(AnthroTraitsMainCreationMethods.initAnthroTraits);
-Events.OnConnected.Add(AnthroTraitsMainCreationMethods.refreshTraitCosts);
 
 
 return AnthroTraitsMain;

--- a/media/lua/shared/AnthroTraitsGlobals.lua
+++ b/media/lua/shared/AnthroTraitsGlobals.lua
@@ -11,7 +11,4 @@ AnthroTraitsGlobals = {
                                          "ISUnloadBulletsFromMagazine", "ISUpgradeWeapon"},
     FoodTags = {"ATCarnivore", "ATHerbivore", "ATInsect", "ATFeralPoison"},
     EvolvedRecipeFoodTags = {"ATCarnivore", "ATHerbivore"},
-    ExclaimPhrases = {"AAAH!", "AAAH!", "AAAH!!", "AEIEEEE!", "EAAH!", "AAAGH!"},
-    ExclaimPhrasesYeen = {"HAHAHAHAHA!", "HAHAHAHAHA!", "HAHAHAHAHA!!", "HUHEHEHEHAHA!", "HAAAAH!", "HEEEHEEEHAHAHAHA!"},
-    ExclaimPhrasesBleater = {"BLEAT!", "BLEAT!", "BLEAT!!", "BLEAAAAT!", "BLEE-EAT!", "EEEEP!"},
 }

--- a/media/lua/shared/NPCs/AnthroTraitsCreationMethods.lua
+++ b/media/lua/shared/NPCs/AnthroTraitsCreationMethods.lua
@@ -1,4 +1,4 @@
-AnthroTraitsMainCreationMethods = {}
+local AnthroTraitsMainCreationMethods = {}
 AnthroTraitsMainCreationMethods.TTF = require("TraitTagFramework");
 
 -- C:\Program Files (x86)\Steam\3steamapps\common\ProjectZomboid\media\lua | Project Zomboid files
@@ -259,6 +259,9 @@ AnthroTraitsMainCreationMethods.sortTraits = function()
     CharacterCreationMain.invertSort(ccp.listboxBadTrait.items)
     CharacterCreationMain.sort(ccp.listboxTraitSelected.items)
 end
+
+Events.OnGameBoot.Add(AnthroTraitsMainCreationMethods.initAnthroTraits);
+Events.OnConnected.Add(AnthroTraitsMainCreationMethods.refreshTraitCosts);
 
 return AnthroTraitsMainCreationMethods;
 

--- a/media/lua/shared/NPCs/AnthroTraitsCreationMethods.lua
+++ b/media/lua/shared/NPCs/AnthroTraitsCreationMethods.lua
@@ -211,13 +211,14 @@ AnthroTraitsMainCreationMethods.refundSelectedAffectedTraits = function()
 
     if selectedItems ~= nil
     then
-        for _, trait in pairs(affectedTraits)
+        for i = 1, #affectedTraits
         do
+            local trait = affectedTraits[i]
             local label = trait:getLabel()
             local newItem;
             --remove traits in selected box
-            for _, entry in pairs(selectedItems) do
-                if entry.item == trait then
+            for j = 1, #selectedItems do
+                if selectedItems[j].item == trait then
                     ccp.pointToSpend = ccp.pointToSpend - tonumber(trait:getRightLabel());
                     ccp.listboxTraitSelected:removeItem(label);
                     if trait:getCost() > 0
@@ -238,8 +239,9 @@ AnthroTraitsMainCreationMethods.sortTraits = function()
     local ccp = MainScreen.instance.charCreationProfession;
     local affectedTraits = this.TTF.GetAllTraitsWithTag("CostVariable");
 
-    for _, trait in pairs(affectedTraits)
+    for i = 1, #affectedTraits
     do
+        local trait = affectedTraits[i]
         local label = trait:getLabel()
         local newItem;
 


### PR DESCRIPTION
I decided to do this in a PR since the formatting is pretty good for it, and you can view the suggested changes easily as commits
The biggest change is just how you use modules: (4ab4c59740d2d3caa549ab38100012a3f27883f1)
```diff
- AnthroTraitsMain = {};
+ local AnthroTraitsMain = {};
```
Module tables should be local, as the purpose of modules is to avoid polluting the global namespace. When we need to reference them in another file, we require them, pulling that module table into a local variable. This also guarantees the load order.
```diff
- local ATM = AnthroTraitsMain;
- local ATC = AnthroTraitsMainCreationMethods;
+ local ATM = require("NPCs/AnthroTraitsMain");
+ local ATC = require("NPCs/AnthroTraitsCreationMethods");
```
Another thing I suggest is preferring for loops over ``pairs()`` when possible. If a table has numeric keys and there are no gaps between them (a table without manually set keys like ``{item, item, item}`` always applies) then a for loop can be used instead, which is much faster but doesn't really require major code changes. (97eb8cddc7b20c5664f3a75c37e5b7adfed4cf37)
```diff
- for _, trait in pairs(affectedTraits)
- do
+ for i = 1, #affectedTraits
+ do
+     local trait = affectedTraits[i]
```
Note: ``ipairs`` does this with ``pairs``-like syntax, but it's basically just a for loop that takes a function call, so it's slightly slower and there's not much reason to use it.

I also moved one of the globals into the module it's used (3f3c205d5d31dd1fe641a5d365a139f56d7e3591) - generally I would prefer to define things in the file they're used/should logically belong to unless they're used in many places. I didn't move any of the others since they were used in files that didn't have modules or didn't clearly belong to one, but generally I would avoid adding to the global namespace. Having a module that stores 'globals' is fine though, and sometimes needed since circular requires aren't possible.