### PR TITLE
57 various food related fixes

### DIFF
--- a/Contents/mods/AnthroTraits/42/media/lua/client/AnthroTraitsFunctionHooks.lua
+++ b/Contents/mods/AnthroTraits/42/media/lua/client/AnthroTraitsFunctionHooks.lua
@@ -220,48 +220,12 @@ ISToolTipInv.render = function(self)
 	local text = "";
 	local leftText = "";
 
-	if (((ATU.FoodVoreType(self.item) == ATGf.HERBIVORE  or ATU.FoodVoreType(self.item) == ATGf.CARNIVORE) and (player:hasTrait(ATGt.HERBIVORE) or player:hasTrait(ATGt.CARNIVORE) or player:hasTrait(ATGt.CARRIONEATER)))
-			or (self.item:hasTag(ATGf.FERALPOISON) and player:hasTrait(ATGt.FERALDIGESTION))
-			or (self.item:hasTag(ATGf.INSECT) and player:hasTrait(ATGt.BUG_O_SSIEUR))
-			or (player:hasTrait(ATGt.FOODMOTIVATED)))
+	local foodProps = ATU.GetConsumableProperties(self.item)
+    local foodChanges = ATU.CalculateFoodChanges(player, self.item, foodProps)
+	
+	if foodChanges.foodTooltip ~= nil
 	then
-		if ATU.FoodVoreType(self.item) == ATGf.HERBIVORE
-		then
-			if player:hasTrait(ATGt.HERBIVORE)
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is more nutritious for you.", self.item)
-			elseif player:hasTrait(ATGt.CARNIVORE)
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, "%LavenderBlush%This food is less nutritious for you.", self.item)
-			elseif player:hasTrait(ATGt.FOODMOTIVATED) or player:hasTrait(ATGt.FERALDIGESTION)
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
-			end
-		elseif ATU.FoodVoreType(self.item) == ATGf.CARNIVORE
-		then
-			if player:hasTrait(ATGt.CARNIVORE) and player:hasTrait(ATGt.CARRIONEATER) and self.item:IsRotten()
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is better for you.", self.item)
-			elseif player:hasTrait(ATGt.CARNIVORE)
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is better for you.", self.item)
-			elseif player:hasTrait(ATGt.CARRIONEATER) and self.item:IsRotten()
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is better for you.", self.item)
-			elseif player:hasTrait(ATGt.CARRIONEATER) and not self.item:IsRotten()
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
-			elseif player:hasTrait(ATGt.HERBIVORE)
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, "%LavenderBlush%This food is worse for you.", self.item)
-			elseif player:hasTrait(ATGt.FOODMOTIVATED) or player:hasTrait(ATGt.FERALDIGESTION)
-			then
-				tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
-			end
-		elseif player:hasTrait(ATGt.FOODMOTIVATED) or player:hasTrait(ATGt.BUG_O_SSIEUR) or player:hasTrait(ATGt.FERALDIGESTION)
-		then
-			tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
-		end
+		tooltipTextTable = ATU.BuildFoodDescription(player, foodProps, foodChanges, self.item)
 	elseif player:hasTrait(ATGt.FERALDIGESTION) and instanceof(self.item, "ComboItem") and self.item:getFluidContainer() ~= nil
 	then
 		if not self.item:getFluidContainer():isEmpty() and self.item:getFluidContainer():getPrimaryFluid():isCategory(FluidCategory.Alcoholic)
@@ -270,11 +234,65 @@ ISToolTipInv.render = function(self)
 		else
 			return oldRender(self);
 		end
-
 	else
 		--If it doesn't have any relevant tags, go instead to oldRender
 		return oldRender(self);
-	end
+	end 
+	
+	-- if (((ATU.FoodVoreType(self.item) == ATGf.HERBIVORE  or ATU.FoodVoreType(self.item) == ATGf.CARNIVORE) and (player:hasTrait(ATGt.HERBIVORE) or player:hasTrait(ATGt.CARNIVORE) or player:hasTrait(ATGt.CARRIONEATER)))
+			-- or (self.item:hasTag(ATGf.FERALPOISON) and player:hasTrait(ATGt.FERALDIGESTION))
+			-- or (self.item:hasTag(ATGf.INSECT) and player:hasTrait(ATGt.BUG_O_SSIEUR))
+			-- or (player:hasTrait(ATGt.FOODMOTIVATED)))
+	-- then
+		-- if ATU.FoodVoreType(self.item) == ATGf.HERBIVORE
+		-- then
+			-- if player:hasTrait(ATGt.HERBIVORE)
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is more nutritious for you.", self.item)
+			-- elseif player:hasTrait(ATGt.CARNIVORE)
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, "%LavenderBlush%This food is less nutritious for you.", self.item)
+			-- elseif player:hasTrait(ATGt.FOODMOTIVATED) or player:hasTrait(ATGt.FERALDIGESTION)
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
+			-- end
+		-- elseif ATU.FoodVoreType(self.item) == ATGf.CARNIVORE
+		-- then
+			-- if player:hasTrait(ATGt.CARNIVORE) and player:hasTrait(ATGt.CARRIONEATER) and self.item:IsRotten()
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is better for you.", self.item)
+			-- elseif player:hasTrait(ATGt.CARNIVORE)
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is better for you.", self.item)
+			-- elseif player:hasTrait(ATGt.CARRIONEATER) and self.item:IsRotten()
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, "%LightGreen%This food is better for you.", self.item)
+			-- elseif player:hasTrait(ATGt.CARRIONEATER) and not self.item:IsRotten()
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
+			-- elseif player:hasTrait(ATGt.HERBIVORE)
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, "%LavenderBlush%This food is worse for you.", self.item)
+			-- elseif player:hasTrait(ATGt.FOODMOTIVATED) or player:hasTrait(ATGt.FERALDIGESTION)
+			-- then
+				-- tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
+			-- end
+		-- elseif player:hasTrait(ATGt.FOODMOTIVATED) or player:hasTrait(ATGt.BUG_O_SSIEUR) or player:hasTrait(ATGt.FERALDIGESTION)
+		-- then
+			-- tooltipTextTable = ATU.BuildFoodDescription(player, nil, self.item)
+		-- end
+	-- elseif player:hasTrait(ATGt.FERALDIGESTION) and instanceof(self.item, "ComboItem") and self.item:getFluidContainer() ~= nil
+	-- then
+		-- if not self.item:getFluidContainer():isEmpty() and self.item:getFluidContainer():getPrimaryFluid():isCategory(FluidCategory.Alcoholic)
+		-- then
+			-- tooltipTextTable = ATU.BuildFluidContainerDescription(player, nil, self.item)
+		-- else
+			-- return oldRender(self);
+		-- end
+	-- else
+		-- --If it doesn't have any relevant tags, go instead to oldRender
+		-- return oldRender(self);
+	-- end
 
 	for i = 1, #tooltipTextTable do
 		text = string.gsub(tooltipTextTable[i], "%%[^%%]+%%", "")

--- a/Contents/mods/AnthroTraits/42/media/lua/client/AnthroTraitsUtilities.lua
+++ b/Contents/mods/AnthroTraits/42/media/lua/client/AnthroTraitsUtilities.lua
@@ -335,7 +335,7 @@ AnthroTraitsUtilities.CalculateFoodChanges = function(character, food, foodProps
 	end
 	
 	-- process UNHAPPINESS and BOREDOM for certain traits (as long as either character is CARRIONEATER or food is fresh or both)
-	if character:hasTrait(ATGt.CARRIONEATER) or not food:IsRotten()
+	if (character:hasTrait(ATGt.CARRIONEATER) and food:hasTag(AnthroTraitsGlobals.FoodTags.CARNIVORE)) or not food:IsRotten()
 	then
 		-- counteract UNHAPPINESS and BOREDOM for certain trait/food combos
 		if (character:hasTrait(ATGt.BUG_O_SSIEUR) and food:hasTag(AnthroTraitsGlobals.FoodTags.INSECT)) or	--BUG_O_SSIEUR doesn't mind eating insects

--- a/Contents/mods/AnthroTraits/42/media/lua/client/AnthroTraitsUtilities.lua
+++ b/Contents/mods/AnthroTraits/42/media/lua/client/AnthroTraitsUtilities.lua
@@ -386,7 +386,7 @@ AnthroTraitsUtilities.CalculateFoodChanges = function(character, food, foodProps
                 result[CharacterStat.POISON] = maxPoisonAmt;
 				result.foodTooltip = -2
             end
-        elseif food:getExtraItems() ~= nil
+        elseif food:haveExtraItems()
         then
 			-- ferals can't process certain ingredients
             local foodIngredients = food:getExtraItems()

--- a/Contents/mods/AnthroTraits/42/media/lua/client/NPCs/AnthroTraitsMain.lua
+++ b/Contents/mods/AnthroTraits/42/media/lua/client/NPCs/AnthroTraitsMain.lua
@@ -230,7 +230,7 @@ AnthroTraitsMain.ApplyFoodChanges = function(character, foodEaten, percentEaten,
 	end
 	if foodChanges.Carbs ~= 0
 	then
-		charNutrition:setCarbs(preCharStats.Carbs + (foodProps.Carbs + foodChanges.Carbs) * percentEaten)
+		charNutrition:setCarbohydrates(preCharStats.Carbs + (foodProps.Carbs + foodChanges.Carbs) * percentEaten)
 	end
 	if foodChanges.Proteins ~= 0
 	then
@@ -241,37 +241,43 @@ AnthroTraitsMain.ApplyFoodChanges = function(character, foodEaten, percentEaten,
 		charNutrition:setLipids(preCharStats.Lipids + (foodProps.Lipids + foodChanges.Lipids) * percentEaten)
 	end
 	-- RabenRabo: I'm not 100% sure what this does...best guess? deal with dangerous uncooked food?
-	if foodEaten:hasTag(AnthroTraitsGlobals.FoodTags.CARNIVORE)
-    then
-        if (character:hasTrait(ATGt.CARNIVORE) or character:hasTrait(ATGt.CARRIONEATER)) and not foodEaten:isRotten()
-        then
-            if instanceof(character, "IsoPlayer") and not foodEaten:isPoison()
-            then
-                character:getModData().ATPlayerData.undoAddedPoison = true;
-                character:getModData().ATPlayerData.beforeEatPoisonLvl = preCharStats[CharacterStat.POISON];
-            end
-        elseif foodEaten:isRotten() and character:hasTrait(ATGt.CARRIONEATER)
-        then
-            if instanceof(character, "IsoPlayer") and not foodEaten:isPoison()
-            then
-                character:getModData().ATPlayerData.undoAddedPoison = true;
-                character:getModData().ATPlayerData.beforeEatPoisonLvl = preCharStats[CharacterStat.POISON];
-            end
-        end
-    elseif foodEaten:hasTag(AnthroTraitsGlobals.FoodTags.HERBIVORE)
-    then
-        if character:hasTrait(ATGt.HERBIVORE)
-        then
-            if not foodEaten:isRotten()
-            then
-                if instanceof(character, "IsoPlayer") and not foodEaten:isPoison()
-                then
-                    character:getModData().ATPlayerData.undoAddedPoison = true;
-                    character:getModData().ATPlayerData.beforeEatPoisonLvl = preCharStats[CharacterStat.POISON];
-                end
-            end
-        end
-    end
+	if foodChanges.undoAddedPoison
+	then
+		character:getModData().ATPlayerData.undoAddedPoison = true;
+		character:getModData().ATPlayerData.beforeEatPoisonLvl = preCharStats[CharacterStat.POISON];
+	end
+	-- -> moved to ATU for more centralized calculations
+	-- if foodEaten:hasTag(AnthroTraitsGlobals.FoodTags.CARNIVORE)
+    -- then
+        -- if (character:hasTrait(ATGt.CARNIVORE) or character:hasTrait(ATGt.CARRIONEATER)) and not foodEaten:isRotten()
+        -- then
+            -- if instanceof(character, "IsoPlayer") and not foodEaten:isPoison()
+            -- then
+                -- character:getModData().ATPlayerData.undoAddedPoison = true;
+                -- character:getModData().ATPlayerData.beforeEatPoisonLvl = preCharStats[CharacterStat.POISON];
+            -- end
+        -- elseif foodEaten:isRotten() and character:hasTrait(ATGt.CARRIONEATER)
+        -- then
+            -- if instanceof(character, "IsoPlayer") and not foodEaten:isPoison()
+            -- then
+                -- character:getModData().ATPlayerData.undoAddedPoison = true;
+                -- character:getModData().ATPlayerData.beforeEatPoisonLvl = preCharStats[CharacterStat.POISON];
+            -- end
+        -- end
+    -- elseif foodEaten:hasTag(AnthroTraitsGlobals.FoodTags.HERBIVORE)
+    -- then
+        -- if character:hasTrait(ATGt.HERBIVORE)
+        -- then
+            -- if not foodEaten:isRotten()
+            -- then
+                -- if instanceof(character, "IsoPlayer") and not foodEaten:isPoison()
+                -- then
+                    -- character:getModData().ATPlayerData.undoAddedPoison = true;
+                    -- character:getModData().ATPlayerData.beforeEatPoisonLvl = preCharStats[CharacterStat.POISON];
+                -- end
+            -- end
+        -- end
+    -- end
 end
 
 AnthroTraitsMain.ExclaimerCheck = function(player)


### PR DESCRIPTION
- moved Poison-Undo check to CalculateFoodChanges()
- moved tooltip good/bad check to CalculateFoodChanges(): result has field foodTooltip (1 = more nutritious, -1 = less nutritious, 0 = no nutritional boni/mali but should show custom tooltip for other reasons, nil = show vanilla tooltip)
- fixed Carrion Eater + Food Motivated liking rotten non-meat but also getting food sickness => now only applies to rotten meat, where food sickness is counteracted
- fixed foodVoreType() check for multi items: getExtraItems() now always returns a list (might be emtpy) => use haveExtraItems() instead
- fixed wrong java API method name: setCarbs() => setCarbohydrates()