### PR TITLE
Fixed eating food completely results in NaN

### DIFF
--- a/Contents/mods/AnthroTraits/42.13/media/lua/client/AnthroTraitsFunctionHooks.lua
+++ b/Contents/mods/AnthroTraits/42.13/media/lua/client/AnthroTraitsFunctionHooks.lua
@@ -148,9 +148,12 @@ local OriginalEatStop = ISEatFoodAction.stop;
 ISEatFoodAction.stop = function(self)
 	-- get stats before original eat result
 	local preStats = GetCharFoodStats(self.character)
+	local foodProps = ATU.GetConsumableProperties(self.item)
+    local foodChanges = ATU.CalculateFoodChanges(self.character, self.item, foodProps)
+
     OriginalEatStop(self);
 	-- apply AT food changes
-	ATM.ApplyFoodChanges(self.character, self.item, self.percentage * self:getJobDelta(), preStats)
+	ATM.ApplyFoodChanges(self.character, self.percentage * self:getJobDelta(), preStats, foodProps, foodChanges)
 end
 
 -- eating process finished completely
@@ -158,9 +161,11 @@ local OriginalEatComplete = ISEatFoodAction.complete;
 ISEatFoodAction.complete = function(self)
 	-- get stats before original eat result
 	local preStats = GetCharFoodStats(self.character)
+	local foodProps = ATU.GetConsumableProperties(self.item)
+    local foodChanges = ATU.CalculateFoodChanges(self.character, self.item, foodProps)
     OriginalEatComplete(self);
 	-- apply AT food changes
-	ATM.ApplyFoodChanges(self.character, self.item, self.percentage * self:getJobDelta(), preStats)
+	ATM.ApplyFoodChanges(self.character, self.percentage * self:getJobDelta(), preStats, foodProps, foodChanges)
 end
 
 

--- a/Contents/mods/AnthroTraits/42.13/media/lua/client/NPCs/AnthroTraitsMain.lua
+++ b/Contents/mods/AnthroTraits/42.13/media/lua/client/NPCs/AnthroTraitsMain.lua
@@ -201,10 +201,8 @@ ATU.ImportExclaimerPhrases()
 -- end
 
 -- overwrites vanilla processing of stats but also avoids clamping issues at 0 and 100
-AnthroTraitsMain.ApplyFoodChanges = function(character, foodEaten, percentEaten, preCharStats)
+AnthroTraitsMain.ApplyFoodChanges = function(character, percentEaten, preCharStats, foodProps, foodChanges)
 	local ATGt = AnthroTraitsGlobals.CharacterTrait
-	local foodProps = ATU.GetConsumableProperties(foodEaten)
-    local foodChanges = ATU.CalculateFoodChanges(character, foodEaten, foodProps)
     local charStats = character:getStats()
     local charNutrition = character:getNutrition()
 	


### PR DESCRIPTION
moved food item related calculations to before original eat complete/stop function calls

NOTE: food tooltip is fine UNLESS you show it while finishing eating complete item, but it basically will only flicker a weird colour once before the item disappears from inventory
NOTE2: eating only a part of a food item (with some left over) didn't result in NaN values but (probably...didn't test) resulted in modifiers being applied to left-over instead of pre-eating food stats.