### PR TITLE
80 fluid related issues

### DIFF
--- a/Contents/mods/AnthroTraits/42.15/media/lua/client/AnthroTraitsFoodTooltip.lua
+++ b/Contents/mods/AnthroTraits/42.15/media/lua/client/AnthroTraitsFoodTooltip.lua
@@ -62,7 +62,7 @@ end
 
 ISToolTipInv.render = function(self)
     local player = self.tooltip:getCharacter();
-    if not self.item or not player then
+    if not self.item or not instanceof(self.item, "InventoryItem") or not player then
         oldRender(self);
         return;
     end

--- a/Contents/mods/AnthroTraits/42.15/media/lua/shared/TimedActions/AT_DrinkFluid_Action.lua
+++ b/Contents/mods/AnthroTraits/42.15/media/lua/shared/TimedActions/AT_DrinkFluid_Action.lua
@@ -12,9 +12,9 @@ function ISDrinkFluidAction:updateEat(delta)
         local consumedRatio = self.startRatio - self.fluidContainer:getFilledRatio();
         local ratioToConsume = targetRatio - consumedRatio;
         local deltaToConsume = ratioToConsume / self.fluidContainer:getFilledRatio();
-        -- deltaToConsume is the amount of fluid consumed per tick, multiplied with alcohol percent and feral poison amount = poison per tick
-        -- NOTE: the numbers tend to get a bit wonky, the longer one drinks (maybe due to FP imprecision?)
-        local poisonDelta = SandboxVars.AnthroTraits.AT_FeralDigestionPoisonAmt * deltaToConsume * self.AT_FeralPoisonPercent;
+        -- deltaToConsume is the percentage of the fluid consumed per tick
+        -- multiply with the amount (liters) in the bottle, the alcohol percent, feral poison amount and constant multiplier = poison per tick
+        local poisonDelta = deltaToConsume * self.fluidContainer:getAmount() * self.AT_FeralPoisonPercent * SandboxVars.AnthroTraits.AT_FeralDigestionPoisonAmt * AnthroTraitsGlobals.FERALDIGESTION_FLUIDMULTIPLIER;
         if not isNaN(poisonDelta) then
             self.character:getStats():add(CharacterStat.POISON, poisonDelta);
         end

--- a/Contents/mods/AnthroTraits/42.15/media/registries.lua
+++ b/Contents/mods/AnthroTraits/42.15/media/registries.lua
@@ -40,6 +40,7 @@ AnthroTraitsGlobals.BULLRUSH_PUSHINTERVAL = 8;
 AnthroTraitsGlobals.BULLRUSH_PUSHRANGE = 1;
 AnthroTraitsGlobals.BULLRUSH_PERZOMBIECOST_MIN = 0.001;
 AnthroTraitsGlobals.BULLRUSH_PERZOMBIECOST_MAX = 0.02;
+AnthroTraitsGlobals.FERALDIGESTION_FLUIDMULTIPLIER = 20;
 
 AnthroTraitsGlobals.CharacterTrait.ANTHROIMMUNITY = CharacterTrait.register("AnthroTraits:AT_AnthroImmunity")
 AnthroTraitsGlobals.CharacterTrait.BEASTOFBURDEN = CharacterTrait.register("AnthroTraits:AT_BeastOfBurden")


### PR DESCRIPTION
Fixed food tooltip for fluid transfer dialog (apparently, a field called "item" does not always have to contain an item)
Fixed Feral Digestion alcohol poisoning calculations:
- uses ingested fluid amount (in liters) instead of percentage
- as a benchmark: 1L of beer (5% alcohol) = Sandbox poison amount
- hard liquor (40% alcohol) is 8x stronger and therefore only needs 125ml to give the Sandbox poison amount
